### PR TITLE
typo fix

### DIFF
--- a/Introduction to Coroutines and Channels/06_StructuredConcurrency.md
+++ b/Introduction to Coroutines and Channels/06_StructuredConcurrency.md
@@ -89,7 +89,7 @@ suspend fun loadContributorsConcurrent(req: RequestData): List<User> = coroutine
 }
 ```
 
-Copy the implementation of `loadContributorsConcurrent` to `loadContributorsNotCancellable` (in `Request6NotCancellable.kt`)
+Copy the implementation of `loadContributorsConcurrent` to `loadContributorsNotCancellable` (in `Request5NotCancellable.kt`)
 and remove the creation of a new `coroutineScope`.
 Our `async` calls now fail to resolve, so we need to start them via `GlobalScope.async`:
 


### PR DESCRIPTION
*Request**6**NotCancellable.kt* does not exist in https://github.com/kotlin-hands-on/intro-coroutines/tree/solutions as far as I can see. However *[Request**5**Concurrent.kt](https://github.com/kotlin-hands-on/intro-coroutines/blob/solutions/src/tasks/Request5Concurrent.kt)* does exist .