### PR TITLE
Update 06_StructuredConcurrency.md

### DIFF
--- a/Introduction to Coroutines and Channels/06_StructuredConcurrency.md
+++ b/Introduction to Coroutines and Channels/06_StructuredConcurrency.md
@@ -1,7 +1,7 @@
 # Structured concurrency
  
 _Coroutine scope_ is responsible for the structure and parent-child relationships between different coroutines.
-We always start new coroutines inside a scope.
+Coroutine builders, like `launch` and `async`, need to be started in some scope. 
 _Coroutine context_ stores additional technical information used to run a given coroutine,
 like the dispatcher specifying the thread or threads the coroutine should be scheduled on.
 


### PR DESCRIPTION
It is a thought sentence. "We always start new coroutines inside a scope." sounds like all we do in scope is starting new coroutines. It is also not true that all coroutines start in some scope. `runBlocking` does not need that, as well as primitives functions and builders from external libraries.