### PR TITLE
fix visualisation glitch

### DIFF
--- a/Targeting iOS and Android with Kotlin Multiplatform/03_CreatingSharedCode.md
+++ b/Targeting iOS and Android with Kotlin Multiplatform/03_CreatingSharedCode.md
@@ -126,6 +126,7 @@ actual fun platformName(): String {
 ```
 
 We create a similar implementation file (and missing directories) for the iOS target in the `SharedCode/src/iosMain/kotlin/actual.kt`:
+
 ```kotlin
 package com.jetbrains.handson.mpp.mobile
 

--- a/Targeting iOS and Android with Kotlin Multiplatform/03_CreatingSharedCode.md
+++ b/Targeting iOS and Android with Kotlin Multiplatform/03_CreatingSharedCode.md
@@ -115,6 +115,7 @@ to provide the platform-specific name from the `expect fun platformName(): Strin
 the `createApplicationScreenMessage` from both Android and iOS applications.
 
 Now we need to create the implementation file (and missing directories) for Android in the `SharedCode/src/androidMain/kotlin/actual.kt`:
+
 ```kotlin
 package com.jetbrains.handson.mpp.mobile
 


### PR DESCRIPTION
There is a small visualization glitch w/o the proposed new line:

<img width="1003" alt="Bildschirmfoto 2019-09-26 um 17 50 28" src="https://user-images.githubusercontent.com/1148268/65704530-fc9e8f00-e086-11e9-972d-054d9e33cb29.png">


with this PR this glitch is fixed:

<img width="731" alt="Bildschirmfoto 2019-09-26 um 17 50 42" src="https://user-images.githubusercontent.com/1148268/65704560-0d4f0500-e087-11e9-9e8e-ea3d6d41edf5.png">
