### PR TITLE
Fix Markdown rendering issues

### DIFF
--- a/Targeting iOS and Android with Kotlin Multiplatform/06_SettingUpKotlinFramework.md
+++ b/Targeting iOS and Android with Kotlin Multiplatform/06_SettingUpKotlinFramework.md
@@ -6,9 +6,10 @@ from console. This task is designed to help to simplify the setup of our iOS Fra
 in the Xcode project model.
 
 We need several binaries from the framework to use it with Xcode:
-- `iOS arm64 debug` --- the binary to run the iOS device in debug mode
-- `iOS arm64 release` --- the binary to include into a release version of an app
-- `iOS x64 debug` --- the binary for iOS simulator, which uses the desktop mac CPU
+
+- `iOS arm64 debug` to run on the iOS device in debug mode
+- `iOS arm64 release` to include into a release version of an app
+- `iOS x64 debug` for the iOS Simulator, which uses the desktop Mac CPU
 
 The easiest way to configure Xcode to use a custom-built framework is to
 place the framework under the same folder for all configurations and targets.

--- a/Targeting iOS and Android with Kotlin Multiplatform/06_SettingUpKotlinFramework.md
+++ b/Targeting iOS and Android with Kotlin Multiplatform/06_SettingUpKotlinFramework.md
@@ -31,6 +31,7 @@ To do this we can double-click on the `KotlinIOS` node (or root node) of the *pr
 to open the *target* settings.
 Next we then click on the `+` in the *Embedded Binaries* section, click *Add Other...* button in the dialog
 to choose the framework from the disk. We can then point to the following folder: 
+
 ```
 SharedCode/build/xcode-frameworks/SharedCode.framework
 ```


### PR DESCRIPTION
Two lists were displaying as paragraphs with hyphens.

![Screen Shot 2019-10-30 at 14 38 20](https://user-images.githubusercontent.com/29010/67888674-f0916b80-fb23-11e9-87b3-56cc6cc109ad.png)
![Screen Shot 2019-10-30 at 14 41 10](https://user-images.githubusercontent.com/29010/67888684-f5eeb600-fb23-11e9-9257-afbd0df5343d.png)

One code display was displaying inline.

![Screen Shot 2019-10-30 at 14 43 27](https://user-images.githubusercontent.com/29010/67888694-fa1ad380-fb23-11e9-9d90-af5f84116a6c.png)

Both issues were fixed by adding newlines before the block content.