### PR TITLE
Fix typo at 06_StructuredConcurrency line 72

### DIFF
--- a/Introduction to Coroutines and Channels/06_StructuredConcurrency.md
+++ b/Introduction to Coroutines and Channels/06_StructuredConcurrency.md
@@ -69,7 +69,7 @@ explicitly, but it won't happen automatically as it would with a structured one.
 
 ### Cancellation of contributors loading
 
-Let's compare two versions of the `loadConstributorsConcurrent` function:
+Let's compare two versions of the `loadContributorsConcurrent` function:
 one using `coroutineScope` to start all the child coroutines and the other using `GlobalScope`.
 We'll compare how both versions behave when we try to cancel the parent coroutine.
 


### PR DESCRIPTION
at line 72  `loadConstributorsConcurrent`  => `loadContributorsConcurrent`
removed  's'