### PR TITLE
Gradle file dependency syntax fix

### DIFF
--- a/Building Web Applications with React and Kotlin JS/02_Setting_up.md
+++ b/Building Web Applications with React and Kotlin JS/02_Setting_up.md
@@ -29,7 +29,7 @@ Inside our `build.gradle.kts` file, let's make sure that our `repositories` bloc
 
 ```kotlin
 repositories {
-    maven("https://kotlin.bintray.com/kotlin-js-wrappers/")
+    maven { url "https://kotlin.bintray.com/kotlin-js-wrappers/" }
     mavenCentral()
     jcenter()
 }
@@ -39,7 +39,7 @@ Now that we have all sources for our dependencies, let's make sure we include ev
 
 ```kotlin
 dependencies {
-    implementation(kotlin("stdlib-js"))
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-js"
 
     //React, React DOM + Wrappers (chapter 3)
     implementation("org.jetbrains:kotlin-react:16.13.0-pre.94-kotlin-1.3.70")


### PR DESCRIPTION
Changed repositories/maven command syntax. 
`kotlin()` command was not found used `implementation "org.jetbrains.kotlin:kotlin-stdlib-js"` instead.

Failed while building on:
IntelliJ IDEA 2019.3.4 (Community Edition)
Build #IC-193.6911.18, built on March 17, 2020
Runtime version: 11.0.6+8-b520.43 x86_64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
macOS 10.15.4
GC: ParNew, ConcurrentMarkSweep
Memory: 1981M
Cores: 8
Registry: 
Non-Bundled Plugins: org.intellij.scala