### PR TITLE
Fix typo in Listing all customers section

### DIFF
--- a/Creating HTTP APIs with Ktor/03_customer-routes.md
+++ b/Creating HTTP APIs with Ktor/03_customer-routes.md
@@ -77,7 +77,7 @@ GET http://0.0.0.0:8080/customer
 Accept: application/json
 ```
 
-When a client makes such a request, content negotiation allows the server can examine the `Accept` header, see if it can serve this specific type of content, and if so, return the result.
+When a client makes such a request, content negotiation allows the server to examine the `Accept` header, see if it can serve this specific type of content, and if so, return the result.
 
 In our case, we're going to install the `ContentNegotitaion` feature and enable its support for JSON. Let's add the following code to the `Application.module()` function:
 


### PR DESCRIPTION
This commit corrects a minor typo in regards to the explanation on what content negotiation is.