### PR TITLE
Clarify where `application.conf` is located

### DIFF
--- a/Creating HTTP APIs with Ktor/02_application-init.md
+++ b/Creating HTTP APIs with Ktor/02_application-init.md
@@ -36,9 +36,9 @@ Let's briefly go through these dependencies one-by-one:
 
 ### Configurations: `application.conf` and `logback.xml`
 
-The repository also includes a basic `application.conf` in HOCON format. Ktor uses this file to determine the port on which it should run, and it also defines the entry point of our application. If you'd like to learn more about how a Ktor server is configured, check out the [official documentation](https://ktor.io/servers/configuration.html).
+The repository also includes a basic `application.conf` in HOCON format, located in the `resources` folder. Ktor uses this file to determine the port on which it should run, and it also defines the entry point of our application. If you'd like to learn more about how a Ktor server is configured, check out the [official documentation](https://ktor.io/servers/configuration.html).
 
-Also included is a `logback.xml` in the `resources` folder, which sets up the basic logging structure for our server. If you'd like to learn more about logging in Ktor, check out the [official documentation](https://ktor.io/servers/logging.html). 
+Also included in the same folder is a `logback.xml` file, which sets up the basic logging structure for our server. If you'd like to learn more about logging in Ktor, check out the [official documentation](https://ktor.io/servers/logging.html). 
 
 ### Entry point
 


### PR DESCRIPTION
While reading this hands-on lab, I found myself wondering where the `application.conf` file was located, and had to look around a little before finding it. It's not a critical change but I think this might slightly improve the user experience.
Let me know your thoughts, I'm also open to changing the wording.