### PR TITLE
Add reference to HOCON definition

### DIFF
--- a/Creating HTTP APIs with Ktor/02_application-init.md
+++ b/Creating HTTP APIs with Ktor/02_application-init.md
@@ -36,7 +36,7 @@ Let's briefly go through these dependencies one-by-one:
 
 ### Configurations: `application.conf` and `logback.xml`
 
-The repository also includes a basic `application.conf` in HOCON format. Ktor uses this file to determine the port on which it should run, and it also defines the entry point of our application. If you'd like to learn more about how a Ktor server is configured, check out the [official documentation](https://ktor.io/servers/configuration.html).
+The repository also includes a basic `application.conf` in [HOCON](https://en.wikipedia.org/wiki/HOCON) format. Ktor uses this file to determine the port on which it should run, and it also defines the entry point of our application. If you'd like to learn more about how a Ktor server is configured, check out the [official documentation](https://ktor.io/servers/configuration.html).
 
 Also included is a `logback.xml` in the `resources` folder, which sets up the basic logging structure for our server. If you'd like to learn more about logging in Ktor, check out the [official documentation](https://ktor.io/servers/logging.html). 
 


### PR DESCRIPTION
I wasn't familiar with this abbreviation so I had to look it up. Adding a reference to the wikipedia definition might help others in their onboarding.
Looking forward to hear your thoughts on this.