### PR TITLE
Add import statement to initial router definition

### DIFF
--- a/Creating HTTP APIs with Ktor/03_customer-routes.md
+++ b/Creating HTTP APIs with Ktor/03_customer-routes.md
@@ -34,6 +34,8 @@ Now that we have a well-defined `Customer` class and a storage for our customer 
 We want to respond to `GET`, `POST`, and `DELETE` requests on the `/customer` endpoint. As such, let's define our routes with the corresponding HTTP methods. Create a file called `CustomerRoutes.kt` in a new package called `routes`, and fill it with the following:
 
 ```kotlin
+import io.ktor.routing.*
+
 fun Route.customerRouting() {
     route("/customer") {
         get {


### PR DESCRIPTION
While running this lab, I had to let IntellJ perform the import and I had to do it for all definitions in this snippet (`Route`, `route`, `get`, ...). I thought that making the import explicit in the snippet might help people that are totally new.
I'm not sure if this is the best way to import what's needed or if adding single imports is preferred, feel free to suggest a better way.