### PR TITLE
Fix Kotlin Multiplatform Mobile plugin link

### DIFF
--- a/Networking and Data Storage with Kotlin Multiplatfrom Mobile/01_Introduction.md
+++ b/Networking and Data Storage with Kotlin Multiplatfrom Mobile/01_Introduction.md
@@ -18,7 +18,7 @@ You can find the [template project](https://github.com/kotlin-hands-on/kmm-netwo
 ## Preparing the local environment
 
 In this tutorial, we will be using 
-* [Android Studio](https://developer.android.com/studio/) with the [Kotlin Multiplatform Mobile plugin](https://plugins.jetbrains.com/plugin/13881-mobile-multiplatform) for working with the shared module and Android project.
+* [Android Studio](https://developer.android.com/studio/) with the [Kotlin Multiplatform Mobile plugin](https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile) for working with the shared module and Android project.
 * [Xcode](https://developer.apple.com/xcode/) for building the iOS application.
 
 Please follow the [setup environment guide](https://kotlinlang.org/docs/mobile/setup.html) for detailed instructions on how to configure your environment.


### PR DESCRIPTION
This PR changes the link the _Preparing the local environment_ section as the current link sends to a 404 page

- Current: https://plugins.jetbrains.com/plugin/13881-mobile-multiplatform

- Proposed change: https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile