### PR TITLE
Update 02_Setting_up.md

### DIFF
--- a/Building Web Applications with React and Kotlin JS/02_Setting_up.md
+++ b/Building Web Applications with React and Kotlin JS/02_Setting_up.md
@@ -101,7 +101,7 @@ Now, we need to compile, run, and serve our code.
 
 The `kotlin.js` Gradle plugin comes by default with support for an embedded `webpack-dev-server`, which allows us to run the application from our IDE without having to manually set up any kind of server.
 
-We can start the development server by invoking the `run` or `browserDevelopmentRun` task from the Gradle tool window inside IntelliJ IDEA:
+We can start the development server by invoking the `run` or `browserDevelopmentRun`(available in `other` directory or `kotlin browser` directory) task from the Gradle tool window inside IntelliJ IDEA:
 
 ![](./assets/browserDevelopmentRun.png)
 


### PR DESCRIPTION
browserDevelopmentRun was not available in `other` directory for me (as it was shown in the image ./assets/browserDevelopmentRun.png ). I found it in `kotlin browser` directory.