### PR TITLE
Update 03_Adding_dependecies.md

### DIFF
--- a/Networking and Data Storage with Kotlin Multiplatfrom Mobile/03_Adding_dependecies.md
+++ b/Networking and Data Storage with Kotlin Multiplatfrom Mobile/03_Adding_dependecies.md
@@ -133,7 +133,7 @@ Add this line to the plugins block at the very beginning of the `build.gradle` f
 ```kotlin
 plugins {
     // ...
-   id("com.squareup.sqldelight")
+   id("com.squareup.sqldelight") version "1.4.4"
 }
 ```
 


### PR DESCRIPTION
Adding the version for sqldelight plugin. Without this version the project give errors.

Per gradle documentation:
To apply a community plugin from the portal, the fully qualified plugin id must be used:
plugins {
    id("com.jfrog.bintray") version "0.4.1"
}
https://docs.gradle.org/current/userguide/plugins.html