### PR TITLE
Update 03_Adding_dependecies.md: "commonMain {" to "val commonMain by getting {"

### DIFF
--- a/Networking and Data Storage with Kotlin Multiplatfrom Mobile/03_Adding_dependecies.md
+++ b/Networking and Data Storage with Kotlin Multiplatfrom Mobile/03_Adding_dependecies.md
@@ -17,7 +17,7 @@ We need to specify a dependency on `kotlinx.coroutines` in the common source set
 val coroutinesVersion = "1.3.9-native-mt"
 
 sourceSets {
-    commonMain {
+    val commonMain by getting {
         dependencies {
             // ...
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")


### PR DESCRIPTION
The first code sample including "commonMain" lacked "val" and "by getting", thus making it inconsistent with the other code samples. Perhaps adding "val" and "by getting" would clarify this code sample for beginner users?