### PR TITLE
Update 05_Building_the_Frontend.md

### DIFF
--- a/Full Stack Web App with Kotlin Multiplatform/05_Building_the_Frontend.md
+++ b/Full Stack Web App with Kotlin Multiplatform/05_Building_the_Frontend.md
@@ -89,7 +89,7 @@ private val scope = MainScope()
 val App = functionalComponent<RProps> { _ ->
     val (shoppingList, setShoppingList) = useState(emptyList<ShoppingListItem>())
 
-    useEffect {
+    useEffectOnce {
         scope.launch {
             setShoppingList(getShoppingList())
         }


### PR DESCRIPTION
useEffect causes the page to constantly call getShoppingList(), infinitely. Instead, use useEffectOnce and it will only call it on load. All other calls are handled via the onSubmit, so no need to call it constantly.