### PR TITLE
Update react-share example link

### DIFF
--- a/Building Web Applications with React and Kotlin JS/07_Using_Packages_From_NPM.md
+++ b/Building Web Applications with React and Kotlin JS/07_Using_Packages_From_NPM.md
@@ -123,7 +123,7 @@ dependencies {
 
 Just like the video player,
 we will need to write some basic external declarations in order to use `react-share` from Kotlin.
-Looking at the [examples on GitHub](https://github.com/nygardk/react-share/blob/master/demo/Demo.jsx#L61),
+Looking at the [examples on GitHub](https://github.com/nygardk/react-share/blob/master/demo/Demo.tsx#L61),
 it becomes clear that each share button consists of two React components.
 For example, there's an`EmailShareButton` and an `EmailIcon`.
 The different types of share buttons and icons all share the same kind of interface, which makes our job easier.


### PR DESCRIPTION
The current version of `react-share` uses a `.tsx` file instead of a `.jsx` file; this PR updates the outdated, broken link.